### PR TITLE
Add Nodemon package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ The container may be used on its own to test exercises directly in the ACOS serv
 or it may be used as an exercise service to
 [the A+ frontend](https://hub.docker.com/r/apluslms/run-aplus-front/)
 ([repository](https://github.com/apluslms/run-aplus-front) and
-[source code](https://github.com/Aalto-LeTech/a-plus)).
+[source code](https://github.com/apluslms/a-plus)).
 
 The image is intended for local testing and development, not for production.
+
+## Developing Acos
 
 The `package.json` file in this repository is used to install additional
 ACOS content types and packages as NPM modules to the container. It replaces
@@ -17,6 +19,15 @@ It is possible to mount ACOS content types and/or packages from the host machine
 into the container in case you want to run and test them in the container while
 developing them. Likewise, ACOS logs may be stored in the host by mounting
 the log directory.
+
+During development it is also possible to run [Nodemon](https://nodemon.io/),
+which allows to automatically reload the server when changes in the content
+types and/or packages are detected (currently HTML, JS, JSON, CSS and XML files
+are supported). By using nodemon it is possible to reduce the number of times
+the docker container needs to be shut down and started again.
+
+In order to use Nodemon you should add the `command: npm run dev`
+option to the `docker-compose.yml` file
 
 ### Usage
 
@@ -41,5 +52,8 @@ services:
       # mount packages under development from the native host (optional)
       - /host/path/to/acos-mycontentpackage/:/usr/src/acos-server/node_modules/acos-mycontentpackage
       - /host/path/to/acos-mycontenttype/:/usr/src/acos-server/node_modules/acos-mycontenttype
+    # the command option is optional and intended for development purpouses of the Acos content types
+    # or Acos packages. If the command option is removed the container will run node instead of nodemon
+    # you can verify the available scripts in the package.json file
+    command: npm run dev
 ```
-

--- a/package.json
+++ b/package.json
@@ -1,8 +1,15 @@
 {
   "name": "acos-server",
   "version": "0.2.2",
+  "nodemonConfig": {
+    "ignoreRoot": [".git"],
+    "ext": "xml, json, js, html, css",
+    "ignore": ["test/*", "docs/*"],
+    "delay": "1000"
+  },
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "dev": "nodemon ./bin/www"
   },
   "dependencies": {
     "acos-annotated": "^0.2.0",
@@ -44,7 +51,8 @@
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",
     "nunjucks": "^3.1.3",
-    "serve-favicon": "^2.5.0"
+    "serve-favicon": "^2.5.0",
+    "nodemon": "^2.0.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description
Add the [nodemon](https://www.npmjs.com/package/nodemon) package. This package allows to automatically reload the server while developing Acos exercises. With this change, the server is reloaded every time a file is changed. However, the developers still need to update the web browser manually. Any case, having this feature will already save a lot of time spent in shutting down and running the *run-acos-server* script every time a change is done in the Acos exercises. The next logical step is to find a way to sync the web browser, but we can do that in a different PR. In addition, these changes, if approved, will need to be implemented in the *acos-server*

# Testing

I tested that the container reloads the server every time a change is made in an XML, JSON or JS file which are used in the Acos exercises.

# Have you updated the README or other relevant documentation?

Readme is updated. Aplus manual needs to be updated.

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
